### PR TITLE
Fix random_slice with small arrays

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -18,7 +18,7 @@ const IMAGE_STATE = {
 }
 
 function random_slice(arr, n) {
-    const i = Math.floor(Math.random()*arr.length - n)
+    const i = Math.max(0, Math.floor(Math.random()*arr.length - n))
     return arr.slice(i, i+n)
 }
 


### PR DESCRIPTION
It doesn't work currently if the array length is smaller than n.
Let's just ensure i is never smaller than 0.